### PR TITLE
win 10  run "Install-Module WiFi-Password" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Now, you can easily install module itself:
 Install-Module WiFi-Password
 ```
 
+If you have this mistake, it is windows [about_Execution_Policies](https://technet.microsoft.com/zh-CN/library/hh847748.aspx)
+![image](https://user-images.githubusercontent.com/23074726/33362000-5701c36a-d515-11e7-864c-9092184a7bc5.png)
+
+You just need to run this command in PowerShell
+```powershell
+set-executionpolicy remotesigned
+```
+
 **2. Use it:**
 
 To get the password for the WiFi you're currently logged onto:


### PR DESCRIPTION
windows 10 in PowerShell run "Install-Module WiFi-Password" command has error, need run this command
```powershell
set-executionpolicy remotesigned
```
to  setting “Execution_Policies” 
[Please click here for more information about Execution_Policies](https://docs.microsoft.com/zh-cn/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-5.1&viewFallbackFrom=powershell-Microsoft.PowerShell.Core)